### PR TITLE
Fix crash when delegate signature_function is null

### DIFF
--- a/Source/Suzie/Private/SuziePlugin.cpp
+++ b/Source/Suzie/Private/SuziePlugin.cpp
@@ -656,6 +656,8 @@ UEnum* FSuziePluginModule::FindOrCreateEnum(FDynamicClassGenerationContext& Cont
 
 UFunction* FSuziePluginModule::FindOrCreateFunction(FDynamicClassGenerationContext& Context, const FString& FunctionPath)
 {
+    if (FunctionPath.IsEmpty()) return nullptr;
+
     // Check if the function already exists
     if (UFunction* ExistingFunction = FindObject<UFunction>(nullptr, *FunctionPath))
     {


### PR DESCRIPTION
If a delegate has signature_function as null, PropertyJson->GetStringField returns an empty string, which is then passed to FindOrCreateFunction. There is already a fallback for when FindOrCreateFunction returns nullptr, but FindOrCreateFunction instead crashes when fed this empty string with the assertion "FindOrCreateFunction expected Function object , got object of type ". This occurs e.g. for ASTRONEER on UE 4.27. This PR handles this behavior by modifying FindOrCreateFunction to return nullptr if fed an empty string for FunctionPath.